### PR TITLE
Fix issue with Grails 3.2.4 (possibly others)

### DIFF
--- a/jaxrs-core/src/main/groovy/org/grails/plugins/jaxrs/core/JaxrsUtil.groovy
+++ b/jaxrs-core/src/main/groovy/org/grails/plugins/jaxrs/core/JaxrsUtil.groovy
@@ -64,7 +64,7 @@ class JaxrsUtil {
             getResourcePaths(it).each {
                 path = buildMappingFromPath(rootPath, it)
                 if(path) {
-                    paths.add(buildMappingFromPath(rootPath, it))
+                    paths.add(path)
                 }
             }
         }

--- a/jaxrs-core/src/main/groovy/org/grails/plugins/jaxrs/core/JaxrsUtil.groovy
+++ b/jaxrs-core/src/main/groovy/org/grails/plugins/jaxrs/core/JaxrsUtil.groovy
@@ -58,10 +58,14 @@ class JaxrsUtil {
         candidates.addAll(jaxrsContext.applicationConfig.classes)
 
         List<String> paths = []
+        String path
         candidates.each {
             Path rootPath = getRootPath(it)
             getResourcePaths(it).each {
-                paths.add(buildMappingFromPath(rootPath, it))
+                path = buildMappingFromPath(rootPath, it)
+                if(path) {
+                    paths.add(buildMappingFromPath(rootPath, it))
+                }
             }
         }
 


### PR DESCRIPTION
To duplicate:

Create new project in Grails 3.2.4 with rest-api profile
Add jaxrs-jersey1 dependency
generate a single resource

For some reason null paths are created and these throw a NumberFormatException from the grails url mapper. Removing these null paths prevents the error. Other behaviour still works.

